### PR TITLE
write literal ${NPM_AUTH_TOKEN} to .npmrc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ workflows:
 
   build:
     jobs:
-      - checkout
+      - checkout:
           context:
             - Globality-Common
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Authenticate NPM
           command: |
-            echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
+            echo '//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}' > .npmrc
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,8 @@ workflows:
   build:
     jobs:
       - checkout
+          context:
+            - Globality-Common
       - lint:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,8 @@ workflows:
   release:
     jobs:
       - checkout:
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,18 @@ workflows:
           context:
             - Globality-Common
       - lint:
+          context:
+            - Globality-Common
           requires:
             - checkout
       - test:
+          context:
+            - Globality-Common
           requires:
             - checkout
       - build:
+          context:
+            - Globality-Common
           requires:
             - lint
             - test
@@ -119,6 +125,8 @@ workflows:
             branches:
               ignore: /.*/
       - lint:
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -127,6 +135,8 @@ workflows:
           requires:
             - checkout
       - test:
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
@@ -135,6 +145,8 @@ workflows:
           requires:
             - checkout
       - build:
+          context:
+            - Globality-Common
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
.npmrc should contain the literal string 
`//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}` rather than the shell interpreting this as a part of the echo statement. Switching to single quotes will do this

npm will later perform the envvar replacement 
